### PR TITLE
Fix comments dependency

### DIFF
--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -27,14 +27,18 @@ declare(strict_types=1);
  *
  */
 
+use Contao\CommentsBundle\ContaoCommentsBundle;
+
 /*
  * Add palettes to tl_module
  */
 $GLOBALS['TL_DCA']['tl_module']['palettes']['formdatalisting'] = '{title_legend},name,headline,type;{config_legend},list_formdata,list_where,list_sort,perPage,list_fields,list_info;{efgSearch_legend},list_search,efg_list_searchtype;{protected_legend:hide},efg_list_access,efg_fe_edit_access,efg_fe_delete_access,efg_fe_export_access;{comments_legend:hide},efg_com_allow_comments;{template_legend:hide},list_layout,list_info_layout;{expert_legend:hide},efg_DetailsKey,efg_iconfolder,efg_fe_keep_id,efg_fe_no_formatted_mail,efg_fe_no_confirmation_mail,align,space,cssID';
 $GLOBALS['TL_DCA']['tl_module']['fields']['type']['load_callback'][] = ['tl_module_efg', 'onloadModuleType'];
 
-$GLOBALS['TL_DCA']['tl_module']['palettes']['__selector__'][] = 'efg_com_allow_comments';
-$GLOBALS['TL_DCA']['tl_module']['subpalettes']['efg_com_allow_comments'] = 'com_moderate,com_bbcode,com_requireLogin,com_disableCaptcha,efg_com_per_page,com_order,com_template,efg_com_notify';
+if (class_exists(ContaoCommentsBundle::class)) {
+    $GLOBALS['TL_DCA']['tl_module']['palettes']['__selector__'][] = 'efg_com_allow_comments';
+    $GLOBALS['TL_DCA']['tl_module']['subpalettes']['efg_com_allow_comments'] = 'com_moderate,com_bbcode,com_requireLogin,com_disableCaptcha,efg_com_per_page,com_order,com_template,efg_com_notify';
+}
 
 /*
  * Add fields to tl_module
@@ -187,59 +191,12 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['efg_com_allow_comments'] = [
     'eval' => ['submitOnChange' => true],
     'sql' => "char(1) NOT NULL default ''",
 ];
-$GLOBALS['TL_DCA']['tl_module']['fields']['com_moderate'] = [
-    'label' => &$GLOBALS['TL_LANG']['tl_module']['com_moderate'],
-    'exclude' => true,
-    'inputType' => 'checkbox',
-    'eval' => ['tl_class' => 'w50'],
-    'sql' => "char(1) NOT NULL default ''",
-];
-$GLOBALS['TL_DCA']['tl_module']['fields']['com_bbcode'] = [
-    'label' => &$GLOBALS['TL_LANG']['tl_module']['com_bbcode'],
-    'exclude' => true,
-    'inputType' => 'checkbox',
-    'eval' => ['tl_class' => 'w50'],
-    'sql' => "char(1) NOT NULL default ''",
-];
-$GLOBALS['TL_DCA']['tl_module']['fields']['com_requireLogin'] = [
-    'label' => &$GLOBALS['TL_LANG']['tl_module']['com_requireLogin'],
-    'exclude' => true,
-    'inputType' => 'checkbox',
-    'eval' => ['tl_class' => 'w50'],
-    'sql' => "char(1) NOT NULL default ''",
-];
-$GLOBALS['TL_DCA']['tl_module']['fields']['com_disableCaptcha'] = [
-    'label' => &$GLOBALS['TL_LANG']['tl_module']['com_disableCaptcha'],
-    'exclude' => true,
-    'inputType' => 'checkbox',
-    'eval' => ['tl_class' => 'w50'],
-    'sql' => "char(1) NOT NULL default ''",
-];
 $GLOBALS['TL_DCA']['tl_module']['fields']['efg_com_per_page'] = [
     'label' => &$GLOBALS['TL_LANG']['tl_module']['efg_com_per_page'],
     'exclude' => true,
     'inputType' => 'text',
     'eval' => ['rgxp' => 'digit', 'tl_class' => 'w50'],
     'sql' => "smallint(5) unsigned NOT NULL default '0'",
-];
-$GLOBALS['TL_DCA']['tl_module']['fields']['com_order'] = [
-    'label' => &$GLOBALS['TL_LANG']['tl_module']['com_order'],
-    'default' => 'ascending',
-    'exclude' => true,
-    'inputType' => 'select',
-    'options' => ['ascending', 'descending'],
-    'reference' => &$GLOBALS['TL_LANG']['MSC'],
-    'eval' => ['tl_class' => 'w50'],
-    'sql' => "varchar(32) NOT NULL default ''",
-];
-$GLOBALS['TL_DCA']['tl_module']['fields']['com_template'] = [
-    'label' => &$GLOBALS['TL_LANG']['tl_module']['com_template'],
-    'default' => 'com_default',
-    'exclude' => true,
-    'inputType' => 'select',
-    'options_callback' => ['tl_module_comments', 'getCommentTemplates'],
-    'eval' => ['tl_class' => 'w50'],
-    'sql' => "varchar(32) NOT NULL default ''",
 ];
 $GLOBALS['TL_DCA']['tl_module']['fields']['efg_com_notify'] = [
     'label' => &$GLOBALS['TL_LANG']['tl_module']['efg_com_notify'],


### PR DESCRIPTION
Currently the following error happens when editing a front end module:

```
RuntimeException:
System::importStatic() failed because class "tl_module_comments" is not a valid class name or does not exist.

  at vendor\contao\core-bundle\src\Resources\contao\library\Contao\System.php:271
  at Contao\System::importStatic()
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\Widget.php:1285)
  at Contao\Widget::getAttributesFromDca()
     (vendor\contao\core-bundle\src\Resources\contao\classes\DataContainer.php:320)
  at Contao\DataContainer->row()
     (vendor\contao\core-bundle\src\Resources\contao\drivers\DC_Table.php:2000)
  at Contao\DC_Table->edit()
     (vendor\contao\core-bundle\src\Resources\contao\classes\Backend.php:644)
  at Contao\Backend->getBackendModule()
     (vendor\contao\core-bundle\src\Resources\contao\controllers\BackendMain.php:167)
  at Contao\BackendMain->run()
     (vendor\contao\core-bundle\src\Controller\BackendController.php:48)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor\symfony\http-kernel\HttpKernel.php:158)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor\symfony\http-kernel\HttpKernel.php:80)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor\symfony\http-kernel\Kernel.php:201)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (web\index.php:34)           
```

This is because EFG duplicates the `tl_module.com_*` DCA fields from the `contao/comments-bundle` and thus also duplicates the `options_callback` of `tl_module.com_template` from an old Contao version. The referenced `tl_module_comments` does not exist anymore in Contao 4.9+.

Since EFG only has a soft dependency on `contao/comments-bundle` it is not necessary to define these DCA fields.