### PR TITLE
Remove SENDMAILCOMMAND

### DIFF
--- a/src/Resources/contao/classes/FormdataProcessor.php
+++ b/src/Resources/contao/classes/FormdataProcessor.php
@@ -27,16 +27,13 @@ declare(strict_types=1);
  *
  */
 
-/* PBD
- * Korrektur zum senden von Mails mittels Contao 4
- * Das sendmail Komanndo wird aus dm Configfile define(SENDMAILCOMMAND,...)
- * gelesen.
- * ist keine define vorhanden bleibt die Einstellung
 /**
  * Namespace
  */
 
 namespace PBDKN\Efgco4\Resources\contao\classes;
+
+use Contao\Email;
 
 /**
  * Class FormdataProcessor.
@@ -446,17 +443,8 @@ class FormdataProcessor extends \Contao\Frontend
             $blnConfirmationSent = false;
 
             if (!empty($objMailProperties->recipients)) {
-                if (SENDMAILCOMMAND) {   // PBD aus config.php
-                    if (SENDMAILCOMMAND=='no_sendmail_path') {
-                        EfgLog::EfgwriteLog(debsmall, __METHOD__, __LINE__, 'no sendmail_path in php.ini ');
-                        $this->log('Could send EMail because no sendmail_path in php.ini', __METHOD__, TL_ERROR);
-                        return;
-                    }          // PBD z.B. zum setzen des -t flags
-                    $this->myMailer->getTransport()->setCommand(sendmail_path.' '.SENDMAILCOMMAND);
-                    EfgLog::EfgwriteLog(debfull, __METHOD__, __LINE__, 'SENDMAILCOMMAND SwiftMailer transport gesetzt => '.SENDMAILCOMMAND);
-                }
                 EfgLog::EfgwriteLog(debfull, __METHOD__, __LINE__, 'vor new Email');
-                $objMail = new \Email($myMailer);
+                $objMail = new Email();
 
                 $objMail->from = $objMailProperties->sender;
 
@@ -593,17 +581,7 @@ class FormdataProcessor extends \Contao\Frontend
             $blnInformationSent = false;
 
             if (!empty($objMailProperties->recipients)) {
-                if (SENDMAILCOMMAND) {   // PBD aus config.php
-                  if (SENDMAILCOMMAND=='no_sendmail_path') {
-                    EfgLog::EfgwriteLog(debsmall, __METHOD__, __LINE__, 'no sendmail_path in php.ini ');
-                    $this->log('Could send EMail because no sendmail_path in php.ini', __METHOD__, TL_ERROR);
-                    return;
-                  }          // PBD z.B. zum setzen des -t flags
-                  $this->myMailer->getTransport()->setCommand(SENDMAILCOMMAND);
-                  EfgLog::EfgwriteLog(debfull, __METHOD__, __LINE__, 'SENDMAILCOMMAND SwiftMailer transport gesetzt => '.SENDMAILCOMMAND);
-                }
-
-                $objMail = new \Email($myMailer);
+                $objMail = new Email();
                 $objMail->from = $objMailProperties->sender;
                 if (!empty($objMailProperties->senderName)) {
                     $objMail->fromName = $objMailProperties->senderName;

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -26,12 +26,7 @@
 
 
 // This file is created when saving a form in form generator
-// last created on 2021-06-04 09:19:44
-/*
- * you can set the swiftmail transport set in efg_internal_config.html
- * example define('SENDMAILCOMMAND', ini_get ('sendmail_path') . ' -t')
-*/
-define('SENDMAILCOMMAND', 'no_sendmail_path');    // set mailtransport for Swiftmailer
+// last created on 2021-09-16 17:40:55
 
 define('debsmall',1);
 define('debmedium',2+debsmall);
@@ -74,7 +69,49 @@ $GLOBALS['BE_MOD']['formdata']['feedback'] = array
 );
 
 // following are used for the form dependent modules
-$GLOBALS['BE_MOD']['formdata']['fd_mytestformular-do'] = array
+$GLOBALS['BE_MOD']['formdata']['fd_anfrage-de'] = array
+(
+	'tables'     => array('tl_formdata', 'tl_formdata_details'),
+	'import'     => array('FormdataBackend', 'importCsv'),
+	'icon'       => 'bundles/contaoefgco4/icons/formdata_all.gif',
+    'stylesheet' => 'bundles/contaoefgco4/css/style.css');
+$GLOBALS['BE_MOD']['formdata']['fd_anfrage-en'] = array
+(
+	'tables'     => array('tl_formdata', 'tl_formdata_details'),
+	'import'     => array('FormdataBackend', 'importCsv'),
+	'icon'       => 'bundles/contaoefgco4/icons/formdata_all.gif',
+    'stylesheet' => 'bundles/contaoefgco4/css/style.css');
+$GLOBALS['BE_MOD']['formdata']['fd_gutschein-de'] = array
+(
+	'tables'     => array('tl_formdata', 'tl_formdata_details'),
+	'import'     => array('FormdataBackend', 'importCsv'),
+	'icon'       => 'bundles/contaoefgco4/icons/formdata_all.gif',
+    'stylesheet' => 'bundles/contaoefgco4/css/style.css');
+$GLOBALS['BE_MOD']['formdata']['fd_kontakt-de'] = array
+(
+	'tables'     => array('tl_formdata', 'tl_formdata_details'),
+	'import'     => array('FormdataBackend', 'importCsv'),
+	'icon'       => 'bundles/contaoefgco4/icons/formdata_all.gif',
+    'stylesheet' => 'bundles/contaoefgco4/css/style.css');
+$GLOBALS['BE_MOD']['formdata']['fd_gutschein-en'] = array
+(
+	'tables'     => array('tl_formdata', 'tl_formdata_details'),
+	'import'     => array('FormdataBackend', 'importCsv'),
+	'icon'       => 'bundles/contaoefgco4/icons/formdata_all.gif',
+    'stylesheet' => 'bundles/contaoefgco4/css/style.css');
+$GLOBALS['BE_MOD']['formdata']['fd_kontakt-en'] = array
+(
+	'tables'     => array('tl_formdata', 'tl_formdata_details'),
+	'import'     => array('FormdataBackend', 'importCsv'),
+	'icon'       => 'bundles/contaoefgco4/icons/formdata_all.gif',
+    'stylesheet' => 'bundles/contaoefgco4/css/style.css');
+$GLOBALS['BE_MOD']['formdata']['fd_anfrage-landingpage-content-de'] = array
+(
+	'tables'     => array('tl_formdata', 'tl_formdata_details'),
+	'import'     => array('FormdataBackend', 'importCsv'),
+	'icon'       => 'bundles/contaoefgco4/icons/formdata_all.gif',
+    'stylesheet' => 'bundles/contaoefgco4/css/style.css');
+$GLOBALS['BE_MOD']['formdata']['fd_anfrage-landingpage-content-en'] = array
 (
 	'tables'     => array('tl_formdata', 'tl_formdata_details'),
 	'import'     => array('FormdataBackend', 'importCsv'),
@@ -93,6 +130,7 @@ array_insert($GLOBALS['FE_MOD']['application'], count($GLOBALS['FE_MOD']['applic
 	'formdatalisting' => 'PBDKN\Efgco4\Resources\contao\modules\ModuleFormdataListing'
 ));
 
+
 // Add backend form fields
 $GLOBALS['BE_FFL']['efgLookupOptionWizard'] = 'PBDKN\Efgco4\Resources\contao\widgets\EfgLookupOptionWizard';
 $GLOBALS['BE_FFL']['efgLookupSelect'] = 'PBDKN\Efgco4\Resources\contao\forms\EfgFormLookupSelectMenu';
@@ -106,6 +144,7 @@ $GLOBALS['TL_FFL']['efgLookupCheckbox'] = 'PBDKN\Efgco4\Resources\contao\forms\E
 $GLOBALS['TL_FFL']['efgLookupRadio'] = 'PBDKN\Efgco4\Resources\contao\forms\EfgFormLookupRadio';
 $GLOBALS['TL_FFL']['efgImageSelect'] = 'PBDKN\Efgco4\Resources\contao\forms\EfgFormImageSelect';
 $GLOBALS['TL_FFL']['efgFormPaginator'] = 'PBDKN\Efgco4\Resources\contao\forms\EfgFormPaginator';
+
 
 /**
  * -------------------------------------------------------------------------

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -26,7 +26,7 @@
 
 
 // This file is created when saving a form in form generator
-// last created on 2021-09-16 17:40:55
+// last created on 2021-06-04 09:19:44
 
 define('debsmall',1);
 define('debmedium',2+debsmall);
@@ -69,49 +69,7 @@ $GLOBALS['BE_MOD']['formdata']['feedback'] = array
 );
 
 // following are used for the form dependent modules
-$GLOBALS['BE_MOD']['formdata']['fd_anfrage-de'] = array
-(
-	'tables'     => array('tl_formdata', 'tl_formdata_details'),
-	'import'     => array('FormdataBackend', 'importCsv'),
-	'icon'       => 'bundles/contaoefgco4/icons/formdata_all.gif',
-    'stylesheet' => 'bundles/contaoefgco4/css/style.css');
-$GLOBALS['BE_MOD']['formdata']['fd_anfrage-en'] = array
-(
-	'tables'     => array('tl_formdata', 'tl_formdata_details'),
-	'import'     => array('FormdataBackend', 'importCsv'),
-	'icon'       => 'bundles/contaoefgco4/icons/formdata_all.gif',
-    'stylesheet' => 'bundles/contaoefgco4/css/style.css');
-$GLOBALS['BE_MOD']['formdata']['fd_gutschein-de'] = array
-(
-	'tables'     => array('tl_formdata', 'tl_formdata_details'),
-	'import'     => array('FormdataBackend', 'importCsv'),
-	'icon'       => 'bundles/contaoefgco4/icons/formdata_all.gif',
-    'stylesheet' => 'bundles/contaoefgco4/css/style.css');
-$GLOBALS['BE_MOD']['formdata']['fd_kontakt-de'] = array
-(
-	'tables'     => array('tl_formdata', 'tl_formdata_details'),
-	'import'     => array('FormdataBackend', 'importCsv'),
-	'icon'       => 'bundles/contaoefgco4/icons/formdata_all.gif',
-    'stylesheet' => 'bundles/contaoefgco4/css/style.css');
-$GLOBALS['BE_MOD']['formdata']['fd_gutschein-en'] = array
-(
-	'tables'     => array('tl_formdata', 'tl_formdata_details'),
-	'import'     => array('FormdataBackend', 'importCsv'),
-	'icon'       => 'bundles/contaoefgco4/icons/formdata_all.gif',
-    'stylesheet' => 'bundles/contaoefgco4/css/style.css');
-$GLOBALS['BE_MOD']['formdata']['fd_kontakt-en'] = array
-(
-	'tables'     => array('tl_formdata', 'tl_formdata_details'),
-	'import'     => array('FormdataBackend', 'importCsv'),
-	'icon'       => 'bundles/contaoefgco4/icons/formdata_all.gif',
-    'stylesheet' => 'bundles/contaoefgco4/css/style.css');
-$GLOBALS['BE_MOD']['formdata']['fd_anfrage-landingpage-content-de'] = array
-(
-	'tables'     => array('tl_formdata', 'tl_formdata_details'),
-	'import'     => array('FormdataBackend', 'importCsv'),
-	'icon'       => 'bundles/contaoefgco4/icons/formdata_all.gif',
-    'stylesheet' => 'bundles/contaoefgco4/css/style.css');
-$GLOBALS['BE_MOD']['formdata']['fd_anfrage-landingpage-content-en'] = array
+$GLOBALS['BE_MOD']['formdata']['fd_mytestformular-do'] = array
 (
 	'tables'     => array('tl_formdata', 'tl_formdata_details'),
 	'import'     => array('FormdataBackend', 'importCsv'),
@@ -130,7 +88,6 @@ array_insert($GLOBALS['FE_MOD']['application'], count($GLOBALS['FE_MOD']['applic
 	'formdatalisting' => 'PBDKN\Efgco4\Resources\contao\modules\ModuleFormdataListing'
 ));
 
-
 // Add backend form fields
 $GLOBALS['BE_FFL']['efgLookupOptionWizard'] = 'PBDKN\Efgco4\Resources\contao\widgets\EfgLookupOptionWizard';
 $GLOBALS['BE_FFL']['efgLookupSelect'] = 'PBDKN\Efgco4\Resources\contao\forms\EfgFormLookupSelectMenu';
@@ -144,7 +101,6 @@ $GLOBALS['TL_FFL']['efgLookupCheckbox'] = 'PBDKN\Efgco4\Resources\contao\forms\E
 $GLOBALS['TL_FFL']['efgLookupRadio'] = 'PBDKN\Efgco4\Resources\contao\forms\EfgFormLookupRadio';
 $GLOBALS['TL_FFL']['efgImageSelect'] = 'PBDKN\Efgco4\Resources\contao\forms\EfgFormImageSelect';
 $GLOBALS['TL_FFL']['efgFormPaginator'] = 'PBDKN\Efgco4\Resources\contao\forms\EfgFormPaginator';
-
 
 /**
  * -------------------------------------------------------------------------

--- a/src/Resources/contao/templates/internal/efg_internal_config.html5
+++ b/src/Resources/contao/templates/internal/efg_internal_config.html5
@@ -28,20 +28,6 @@
 
 <?php echo '// This file is created when saving a form in form generator' . PHP_EOL; ?>
 <?php echo '// last created on ' .date("Y-m-d H:i:s") . PHP_EOL; ?>
-<?php
-  // PBD SENDMAILCOMMAND
-  echo '/*' . PHP_EOL;
-  echo ' * you can set the swiftmail transport set in efg_internal_config.html' . PHP_EOL;
-  echo " * example define('SENDMAILCOMMAND', ini_get ('sendmail_path') . ' -t')" . PHP_EOL;
-  echo '*/' . PHP_EOL;
-
-if(ini_get('sendmail_path')){
-  echo "define('SENDMAILCOMMAND', ini_get ('sendmail_path') . ' -t');   // set mailtransport for Swiftmailer". PHP_EOL;
-  echo "                                                              // for standard comment out this line". PHP_EOL;
-} else {
-  echo "define('SENDMAILCOMMAND', 'no_sendmail_path');    // set mailtransport for Swiftmailer". PHP_EOL;
-}
-?>
 
 define('debsmall',1);
 define('debmedium',2+debsmall);


### PR DESCRIPTION
These removes any references to the `SENDMAILCOMMAND` constant. Email configuration should be done via Contao and not via such a constant. And this does not work correctly anyway.